### PR TITLE
fix: add fisher bootstrap and expand topgrade config

### DIFF
--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -1,3 +1,8 @@
+# Bootstrap fisher if not installed (fish plugin manager)
+if not command -v fisher >/dev/null 2>&1
+    curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | fish
+end
+
 function fish_greeting
     fastfetch
 end

--- a/home/dot_config/topgrade.toml
+++ b/home/dot_config/topgrade.toml
@@ -1,2 +1,58 @@
+# =============================================================================
+# topgrade.toml — what topgrade updates and what it skips
+# =============================================================================
+# Run: topgrade
+# Docs: https://topgrade.dev/
+
+# ── Things to never touch ──────────────────────────────────────────────────
 [misc]
-disable = ["containers", "gem", "helm", "ruby_gems"]
+disable = [
+  # container runtimes / orchestrators
+  "containers",      # Docker/Podman/etc — usually managed separately
+  # language-specific package managers you don't use
+  "gem",             # Ruby gems — disabled
+  "helm",           # Helm charts — disabled
+  "ruby_gems",      # Ruby gems — disabled
+  # Linux-specific
+  "flatpak",        # Flatpak — not typically used
+  "snap",           # Snap packages — not typically used
+  # system-level / rarely needed
+  "powershell",     # PowerShell Gallery — unlikely on your machines
+  "emacs",          # Emacs packages — not your editor
+  "lvim",           # LunarVim — not installed
+  "winget",         # Windows only
+  # OS-level (homebrew handles macOS updates; linuxbrew handles Linux)
+  "system",
+  # stay away from things that might interfere with running processes
+  "linux_update",
+  # other
+  "restarts",       # don't restart services after update
+  "v Box",          # VirtualBox — usually managed manually
+]
+
+# ── Things you DO want updated ────────────────────────────────────────────
+[linuxbrew]
+enabled = true
+
+[homebrew]
+enabled = true
+# don't ask for sudo/password interactively
+args = ["--force"]
+
+[cargo]
+enabled = true
+
+[rustup]
+enabled = true
+
+[npm]
+enabled = true
+
+[vcprompt]
+enabled = false  # not installed
+
+[atuin]
+enabled = true
+
+[brew_cask]
+enabled = true


### PR DESCRIPTION
## What

**Fisher auto-bootstrap** — `config.fish.tmpl` now bootstraps fisher on first fish shell load if it's not already installed. Fixes the issue where fish plugins wouldn't load on a fresh machine without fisher pre-installed.

**Expanded topgrade config** — `topgrade.toml` expanded from 4 disables to a full intentional config:
- Disabled: flatpak, snap, emacs, lvim, winget, powershell, system, linux_update, restarts, vbox — things not used or that interfere with running services
- Enabled: brew, brew_cask, cargo, rustup, npm, atuin, linuxbrew — tools actually in use
- Adds comments explaining the rationale so future maintainers know why things are skipped

## Testing

- Fisher bootstrap is idempotent — safe to reload fish shell multiple times
- Run `topgrade` to verify the config is valid and it only offers to update the expected things
