### PR TITLE
fix: move work email prompt to chezmoi config template

### DIFF
--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -2,7 +2,13 @@
 
 {{- $personal = promptBool "personal" -}}
 
+{{- $workEmail := "" -}}
+{{- if not $personal }}
+{{-   $workEmail = promptString "Enter your work email for git commits" -}}
+{{- end }}
+
 format: yaml
 data:
   name: "Jory Irving"
   personal: {{ $personal | quote }}
+  workEmail: {{ $workEmail | quote }}

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -3,7 +3,7 @@
 {{- if .personal }}
   email = jory@jory.dev
 {{- else }}
-  email = {{ prompt "Enter your email for git commits" }}
+  email = {{ .workEmail }}
 {{- end }}
 {{- if (eq .chezmoi.os "darwin") }}
   signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICqvMKxuiIVq0y5yQQrHDXuIBxpch0hkYxGMOq7XyZEi


### PR DESCRIPTION
## What

Fixes the chezmoi template error on `dot_gitconfig.tmpl`:
```
chezmoi: .gitconfig: template: dot_gitconfig.tmpl:6: function "promptString" not defined
```

**Root cause:** `promptString` works in `.chezmoi.yaml.tmpl` (the config template) but not in `dot_gitconfig.tmpl` (a target file template) — they run in different template contexts.

**Fix:**
- Work email prompt moved to `.chezmoi.yaml.tmpl` where `promptString` is available
- Stored as `data.workEmail` in the computed config
- `dot_gitconfig.tmpl` references `{{ .workEmail }}` instead of calling the prompt

On first run (`chezmoi init --apply`): prompts for `personal` (bool) and `workEmail` (string if personal=false). On subsequent runs: uses cached values.
