### PR TITLE
Manage Zed + OpenCode configs with a work/personal split

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "home/.chezmoitemplates/work"]
+	path = home/.chezmoitemplates/work
+	url = git@github.com:joryirving/dotfiles-work.git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,6 @@
 set -euo pipefail
 
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/joryirving/dotfiles.git}"
-DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.local/share/dotfiles}"
 CHEZMOI_BIN="$HOME/.local/bin/chezmoi"
 
 # -----------------------------------------------------------------------------
@@ -201,27 +200,18 @@ install_mise
 install_fisher
 
 # -----------------------------------------------------------------------------
-# Step 4: clone or update dotfiles repo
+# Step 4: initialize dotfiles with chezmoi
 # -----------------------------------------------------------------------------
-info "Setting up dotfiles..."
-if [[ -d "$DOTFILES_DIR/.git" ]]; then
-  info "  dotfiles already cloned at $DOTFILES_DIR — pulling latest..."
-  git -C "$DOTFILES_DIR" pull --ff-only
-else
-  info "  cloning dotfiles to $DOTFILES_DIR..."
-  mkdir -p "$(dirname "$DOTFILES_DIR")"
-  git clone --bare "$DOTFILES_REPO" "$DOTFILES_DIR"
-fi
-
-# Ensure chezmoi can find the repo
-exportchezmoi config:
-  git -C "$DOTFILES_DIR" config --local init.defaultBranch main
-
-# -----------------------------------------------------------------------------
-# Step 5: run chezmoi init
-# -----------------------------------------------------------------------------
-info "Running chezmoi init — you will be prompted for work/personal setup..."
-chezmoi init --apply --source="$DOTFILES_DIR"
+# `chezmoi init` clones the repo into its source dir (~/.local/share/chezmoi),
+# recurses submodules (the private `work` overlay), and applies. You will be
+# prompted for the work/personal setup on first run.
+#
+# NOTE: the private work submodule is fetched over SSH (git@github.com), so a
+# GitHub SSH key must be available — e.g. via the 1Password SSH agent — before
+# running this. On a brand-new machine, set that up first; otherwise re-run
+# `chezmoi init` once SSH is ready and the work overlay will be pulled in.
+info "Initializing dotfiles with chezmoi (prompts for work/personal setup)..."
+"$CHEZMOI_BIN" init --apply "$DOTFILES_REPO"
 
 info "Bootstrap complete!"
 info ""

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -2,13 +2,7 @@
 
 {{- $personal = promptBool "personal" -}}
 
-{{- $workEmail := "" -}}
-{{- if not $personal }}
-{{-   $workEmail = promptString "Enter your work email for git commits" -}}
-{{- end }}
-
 format: yaml
 data:
   name: "Jory Irving"
-  personal: {{ $personal | quote }}
-  workEmail: {{ $workEmail | quote }}
+  personal: {{ $personal }}

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+{{- if .personal }}
+  , "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#f2cbfbe"]
+  , "enabled_providers": ["lmstudio", "litellm-anthropic", "litellm"]
+  , "model": "litellm/self-hosted"
+  , "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio",
+      "options": {
+        "baseURL": "http://macbookpro.internal:1234/v1"
+      },
+      "models": {
+        "qwen3.6-35b-a3b": { "name": "Qwen3.6 35B-A3B" },
+        "gemma-4-26b-a4b-it-qat": { "name": "Gemma 4 26B" }
+      }
+    },
+    "litellm-anthropic": {
+      "npm": "@ai-sdk/anthropic",
+      "name": "LiteLLM Anthropic",
+      "options": {
+        "baseURL": "https://litellm.jory.dev/v1",
+        "authToken": "{{ onepasswordRead "op://Kubernetes/litellm/LITELLM_MASTER_KEY" }}",
+        "timeout": 300000
+      },
+      "models": {
+        "MiniMax-M2.7": { "name": "MiniMax M2.7" },
+        "MiniMax": { "name": "MiniMax M3" }
+      }
+    },
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM OpenAI",
+      "options": {
+        "baseURL": "https://litellm.jory.dev/v1",
+        "apiKey": "{{ onepasswordRead "op://Kubernetes/litellm/LITELLM_MASTER_KEY" }}",
+        "timeout": 1800000
+      },
+      "models": {
+        "self-hosted": { "name": "Qwen3.6-35B-A3B", "limit": { "context": 262144, "output": 16384 } },
+        "nvidia": { "name": "Qwen3.6-27B", "limit": { "context": 200000, "output": 16384 } },
+        "cheap-coder": { "name": "OpenCode Go DeepSeek V4 Flash", "limit": { "context": 1000000, "output": 16384 } },
+        "reasoning-coder": { "name": "OpenCode Go GLM 5.1", "limit": { "context": 203000, "output": 16384 } },
+        "kimi-k2.6": { "name": "Kimi K2.6", "limit": { "context": 262144, "output": 262144 } }
+      }
+    }
+  }
+  , "mcp": {
+    "mcp-server-context7": {
+      "type": "local",
+      "command": ["npx", "-y", "@upstash/context7-mcp"],
+      "enabled": true,
+      "environment": {
+        "CONTEXT7_API_KEY": "{{ onepasswordRead "op://Kubernetes/context7/OPENCODE_API_KEY" }}"
+      }
+    },
+    "memory": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-memory"],
+      "enabled": true
+    },
+    "github": {
+      "type": "local",
+      "command": ["/opt/homebrew/lib/node_modules/@modelcontextprotocol/server-github/dist/index.js"],
+      "enabled": true,
+      "environment": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Kubernetes/github-miso/GITHUB_TOKEN" }}"
+      }
+    },
+    "toolhive": {
+      "type": "remote",
+      "url": "https://mcp.jory.dev/mcp"
+    },
+    "kubectl": {
+      "type": "local",
+      "command": ["/opt/homebrew/lib/node_modules/@strowk/mcp-k8s-darwin-arm64/bin/mcp-k8s-go"],
+      "enabled": true
+    },
+    "dispatch": {
+      "type": "local",
+      "command": ["npx", "tsx", "{{ .chezmoi.homeDir }}/git/dispatch/src/mcp/server.ts"],
+      "enabled": true,
+      "environment": {
+        "DISPATCH_URL": "https://dispatch.jory.dev",
+        "DISPATCH_AGENT_TOKEN": "{{ onepasswordRead "op://Kubernetes/dispatch/DISPATCH_AGENT_TOKEN" }}"
+      }
+    }
+  }
+{{- else }}
+{{ includeTemplate "work/opencode.json" . }}
+{{- end }}
+}

--- a/home/dot_config/zed/settings.json.tmpl
+++ b/home/dot_config/zed/settings.json.tmpl
@@ -1,0 +1,191 @@
+// Zed settings — managed by chezmoi.
+// Shared settings are below; machine-specific blocks are split by the `personal`
+// prompt. Work (non-personal) blocks come from the private `work` submodule.
+{
+  "telemetry": {
+    "diagnostics": false,
+    "metrics": false,
+  },
+  "base_keymap": "VSCode",
+  "ui_font_size": 16,
+  "buffer_font_size": 15,
+  "autosave": "on_focus_change",
+  "session": {
+    "trust_all_worktrees": true,
+  },
+  "outline_panel": {
+    "dock": "left",
+  },
+  "collaboration_panel": {
+    "dock": "left",
+  },
+  "git_panel": {
+    "dock": "left",
+  },
+  "project_panel": {
+    "dock": "left",
+  },
+{{- if .personal }}
+  // ---- personal ----
+  "edit_predictions": {
+    "provider": "open_ai_compatible_api",
+    "open_ai_compatible_api": {
+      "model": "mellum2-12b-a2.5b-thinking",
+      "api_url": "http://macbookpro.internal:1234/v1",
+    },
+  },
+  "context_servers": {
+    "mcp-server-context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"],
+      "env": {
+        "CONTEXT7_API_KEY": "{{ onepasswordRead "op://Kubernetes/context7/ZED_API_KEY" }}",
+      },
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+    },
+    "github": {
+      "command": "/opt/homebrew/lib/node_modules/@modelcontextprotocol/server-github/dist/index.js",
+      "args": [],
+      "env": {
+        "GITHUB_TOKEN": "{{ onepasswordRead "op://Kubernetes/github-miso/GITHUB_TOKEN" }}",
+      },
+    },
+    "toolhive": {
+      "url": "https://mcp.jory.dev/mcp",
+    },
+    "kubectl": {
+      "command": "/opt/homebrew/lib/node_modules/@strowk/mcp-k8s-darwin-arm64/bin/mcp-k8s-go",
+      "args": [],
+    },
+    "dispatch": {
+      "command": "npx",
+      "args": ["tsx", "{{ .chezmoi.homeDir }}/git/dispatch/src/mcp/server.ts"],
+      "env": {
+        "DISPATCH_URL": "https://dispatch.jory.dev",
+        "DISPATCH_AGENT_TOKEN": "{{ onepasswordRead "op://Kubernetes/dispatch/DISPATCH_AGENT_TOKEN" }}",
+      },
+    },
+  },
+  "language_models": {
+    "lmstudio": {
+      "api_url": "http://macbookpro.internal:1234/v1",
+    },
+    "openai_compatible": {
+      "LiteLLM": {
+        "api_url": "https://litellm.jory.dev/v1",
+        "available_models": [
+          {
+            "name": "self-hosted",
+            "max_tokens": 262144,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": true, "parallel_tool_calls": true, "prompt_cache_key": false, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "nvidia",
+            "max_tokens": 131072,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": true, "parallel_tool_calls": true, "prompt_cache_key": false, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "review",
+            "max_tokens": 262144,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": true, "parallel_tool_calls": false, "prompt_cache_key": false, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "kimi-k2.6",
+            "max_tokens": 262144,
+            "max_output_tokens": 262144,
+            "capabilities": { "tools": true, "images": false, "parallel_tool_calls": false, "prompt_cache_key": true, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "opencode-go-glm-5.1",
+            "max_tokens": 203000,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": false, "parallel_tool_calls": false, "prompt_cache_key": true, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "opencode-go-deepseek-v4-flash",
+            "max_tokens": 1000000,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": false, "parallel_tool_calls": false, "prompt_cache_key": true, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "opencode-go-deepseek-v4-pro",
+            "max_tokens": 1000000,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": false, "parallel_tool_calls": false, "prompt_cache_key": true, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "cheap-coder",
+            "max_tokens": 1000000,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": false, "parallel_tool_calls": false, "prompt_cache_key": true, "chat_completions": true, "interleaved_reasoning": false }
+          },
+          {
+            "name": "reasoning-coder",
+            "max_tokens": 203000,
+            "max_output_tokens": 16384,
+            "capabilities": { "tools": true, "images": false, "parallel_tool_calls": false, "prompt_cache_key": true, "chat_completions": true, "interleaved_reasoning": false }
+          }
+        ]
+      }
+    },
+    "anthropic": {
+      "api_url": "https://litellm.jory.dev",
+      "available_models": [
+        {
+          "name": "MiniMax",
+          "display_name": "MiniMax",
+          "max_tokens": 1000000,
+          "max_output_tokens": 131072
+        }
+      ]
+    },
+  },
+  "agent": {
+    "default_model": {
+      "provider": "LiteLLM",
+      "model": "nvidia",
+      "enable_thinking": false,
+    },
+    "sidebar_side": "right",
+    "dock": "right",
+    "favorite_models": [
+      { "provider": "LiteLLM", "model": "self-hosted", "enable_thinking": false },
+      { "provider": "anthropic", "model": "MiniMax", "enable_thinking": false },
+      { "provider": "LiteLLM", "model": "cheap-coder", "enable_thinking": false },
+      { "provider": "LiteLLM", "model": "opencode-go-deepseek-v4-pro", "enable_thinking": false },
+      { "provider": "LiteLLM", "model": "reasoning-coder", "enable_thinking": false },
+    ],
+    "model_parameters": [],
+  },
+  "file_types": {
+    "json5": ["*.json5"],
+  },
+  "line_ending": "prefer_lf",
+  "agent_servers": {
+    "codex-acp": {
+      "default_config_options": {
+        "reasoning_effort": "medium",
+        "model": "gpt-5.4",
+        "mode": "full-access",
+      },
+      "type": "registry",
+      "env": {
+        "CODEX_HOME": "{{ .chezmoi.homeDir }}/.codex",
+      },
+    },
+  },
+  "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "One Dark",
+  },
+{{- else }}
+{{ includeTemplate "work/zed.json" . }}
+{{- end }}
+}

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -4,7 +4,7 @@
   email = jory@jory.dev
   signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAimDt26wJWaZLR0yUeDHCD4hvPBMa1tD3Uos/3kehZ0
 {{- else }}
-  email = {{ .workEmail }}
+  email = {{ onepasswordRead "op://Private/Stackadapt/username" }}
   signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICqvMKxuiIVq0y5yQQrHDXuIBxpch0hkYxGMOq7XyZEi
 {{- end }}
 {{- if or (eq .chezmoi.os "darwin") (and (eq .chezmoi.os "linux") (.chezmoi.kernel.osrelease | lower | contains "microsoft")) }}


### PR DESCRIPTION
## What

Brings `~/.config/zed/settings.json` and `~/.config/opencode/opencode.json` under chezmoi with a work/personal split.

- **Personal** config lives inline under `{{ if .personal }}`.
- **Work** config is pulled from a new **private** `dotfiles-work` submodule at `home/.chezmoitemplates/work/`, so StackAdapt-internal hostnames and model catalogs never appear in this public repo.
- **Secrets** are resolved at `chezmoi apply` time via 1Password (`onepasswordRead`) and `gh auth token` — no raw secrets in either repo (scanned).

## Audited against live backends

Every model name was reconciled against the real source:
- Work Zed/OpenCode → live **Bifrost** API + work LM Studio (fixed 3 Claude IDs that used an invalid `us.` prefix)
- Personal Zed/OpenCode → **litellm** configmap + personal Mac LM Studio (removed dead `opencode-go-kimi-k2.6`, `local-small`, `kimi-k2.5`; added the missing LM Studio provider to personal OpenCode)
- Work OpenCode reworked to mirror work Zed; personal OpenCode MCP set now matches personal Zed.

## Also

- Store `personal` as a real boolean (was a string → always truthy, silently forcing the personal branch).
- Pull work git email from 1Password; drop the `workEmail` init prompt.
- `bootstrap.sh`: chezmoi-native init that recurses the submodule (also fixes a broken line).

> Note: the work submodule fetches over SSH, so a GitHub SSH key (1Password agent) must be present before `chezmoi init` on a new machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)