### PR TITLE
Fix off-Mac opencode MCP (toolhive router), drop memory MCP, renovate for plugins

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,4 +5,15 @@
     'github>joryirving/renovate-config',
     ':semanticCommits',
   ],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'opencode npm plugins pinned as @scope/name@version',
+      managerFilePatterns: ['/opencode\\.json\\.tmpl$/'],
+      // ["@eleboucher/opencode-memini@0.3.2", { ... }]
+      matchStrings: ['(?<depName>@[\\w.-]+/[\\w.-]+)@(?<currentValue>\\d[\\w.-]*)'],
+      datasourceTemplate: 'npm',
+      versioningTemplate: 'npm',
+    },
+  ],
 }

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -73,14 +73,6 @@
       "command": ["npx", "-y", "@modelcontextprotocol/server-memory"],
       "enabled": true
     },
-    "github": {
-      "type": "local",
-      "command": ["/opt/homebrew/lib/node_modules/@modelcontextprotocol/server-github/dist/index.js"],
-      "enabled": true,
-      "environment": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Kubernetes/github-miso/GITHUB_TOKEN" }}"
-      }
-    },
     "toolhive": {
       "type": "remote",
       "url": "https://mcp.jory.dev/mcp"
@@ -88,19 +80,6 @@
     "konflate": {
       "type": "remote",
       "url": "https://konflate.jory.dev/mcp"
-    },
-    "kubectl": {
-      "type": "local",
-      "command": ["/opt/homebrew/lib/node_modules/@strowk/mcp-k8s-darwin-arm64/bin/mcp-k8s-go"],
-      "enabled": true
-    },
-    "flux": {
-      "type": "local",
-      "command": ["/opt/homebrew/bin/flux-operator-mcp", "serve"],
-      "enabled": true,
-      "environment": {
-        "KUBECONFIG": "{{ .chezmoi.homeDir }}/.kube/config"
-      }
     },
     "dispatch": {
       "type": "local",
@@ -111,6 +90,31 @@
         "DISPATCH_AGENT_TOKEN": "{{ onepasswordRead "op://Kubernetes/dispatch/DISPATCH_AGENT_TOKEN" }}"
       }
     }
+    {{- if eq .chezmoi.os "darwin" }}
+    {{/* macOS-only local servers (Homebrew binaries). Off-Mac (e.g. Rpi5 jumpbox)
+         these tools are reached through the toolhive gateway, which aggregates them. */}}
+    , "github": {
+      "type": "local",
+      "command": ["/opt/homebrew/lib/node_modules/@modelcontextprotocol/server-github/dist/index.js"],
+      "enabled": true,
+      "environment": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{{ onepasswordRead "op://Kubernetes/github-miso/GITHUB_TOKEN" }}"
+      }
+    }
+    , "kubectl": {
+      "type": "local",
+      "command": ["/opt/homebrew/lib/node_modules/@strowk/mcp-k8s-darwin-arm64/bin/mcp-k8s-go"],
+      "enabled": true
+    }
+    , "flux": {
+      "type": "local",
+      "command": ["/opt/homebrew/bin/flux-operator-mcp", "serve"],
+      "enabled": true,
+      "environment": {
+        "KUBECONFIG": "{{ .chezmoi.homeDir }}/.kube/config"
+      }
+    }
+    {{- end }}
   }
   , "agent": {
     "lean": {
@@ -127,14 +131,20 @@
       }
     },
     "gitops": {
-      "description": "Cluster ops — kubectl, flux, konflate only",
+      "description": "Cluster ops — kubectl/flux/konflate direct on macOS; via toolhive router off-Mac",
       "mode": "primary",
       "tools": {
         "mcp-server-context7*": false,
         "memory*": false,
         "github*": false,
-        "toolhive*": false,
         "dispatch*": false
+        {{- if eq .chezmoi.os "darwin" }}
+        {{/* kubectl/flux run as local binaries here, so reach them directly and
+             skip the toolhive router. */}}
+        , "toolhive*": false
+        {{- end }}
+        {{/* Off-Mac the local binaries are absent (see mcp block), so toolhive is
+             left enabled — its find_tool/call_tool router reaches kubectl/flux/etc. */}}
       }
     }
   }

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -68,11 +68,6 @@
         "CONTEXT7_API_KEY": "{{ onepasswordRead "op://Kubernetes/context7/OPENCODE_API_KEY" }}"
       }
     },
-    "memory": {
-      "type": "local",
-      "command": ["npx", "-y", "@modelcontextprotocol/server-memory"],
-      "enabled": true
-    },
     "toolhive": {
       "type": "remote",
       "url": "https://mcp.jory.dev/mcp"
@@ -122,7 +117,6 @@
       "mode": "primary",
       "tools": {
         "mcp-server-context7*": false,
-        "memory*": false,
         "github*": false,
         "kubectl*": false,
         "flux*": false,
@@ -135,7 +129,6 @@
       "mode": "primary",
       "tools": {
         "mcp-server-context7*": false,
-        "memory*": false,
         "github*": false,
         "dispatch*": false
         {{- if eq .chezmoi.os "darwin" }}

--- a/home/dot_config/zed/settings.json.tmpl
+++ b/home/dot_config/zed/settings.json.tmpl
@@ -46,6 +46,8 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-memory"],
     },
+    // macOS-only local server (Homebrew binary); off-Mac it's reached via toolhive.
+    {{- if eq .chezmoi.os "darwin" }}
     "github": {
       "command": "/opt/homebrew/lib/node_modules/@modelcontextprotocol/server-github/dist/index.js",
       "args": [],
@@ -53,6 +55,7 @@
         "GITHUB_TOKEN": "{{ onepasswordRead "op://Kubernetes/github-miso/GITHUB_TOKEN" }}",
       },
     },
+    {{- end }}
     "memini": {
       "url": "https://memini.jory.dev/mcp",
       "headers": { "X-Memini-Namespace": "zed" },
@@ -63,6 +66,8 @@
     "konflate": {
       "url": "https://konflate.jory.dev/mcp",
     },
+    // macOS-only local servers (Homebrew binaries); off-Mac reached via toolhive.
+    {{- if eq .chezmoi.os "darwin" }}
     "kubectl": {
       "command": "/opt/homebrew/lib/node_modules/@strowk/mcp-k8s-darwin-arm64/bin/mcp-k8s-go",
       "args": [],
@@ -74,6 +79,7 @@
         "KUBECONFIG": "{{ .chezmoi.homeDir }}/.kube/config",
       },
     },
+    {{- end }}
     "dispatch": {
       "command": "npx",
       "args": ["tsx", "{{ .chezmoi.homeDir }}/git/dispatch/src/mcp/server.ts"],

--- a/home/dot_config/zed/settings.json.tmpl
+++ b/home/dot_config/zed/settings.json.tmpl
@@ -42,10 +42,6 @@
         "CONTEXT7_API_KEY": "{{ onepasswordRead "op://Kubernetes/context7/ZED_API_KEY" }}",
       },
     },
-    "memory": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"],
-    },
     // macOS-only local server (Homebrew binary); off-Mac it's reached via toolhive.
     {{- if eq .chezmoi.os "darwin" }}
     "github": {


### PR DESCRIPTION
## What & why

Tidies up the personal opencode + zed MCP setup so the Linux (Rpi5) jump-box works, and adds renovate coverage for opencode plugins.

### Gate macOS-only MCP servers off-Mac (`ceaf644`)
`github`/`kubectl`/`flux` are local Homebrew binaries with darwin paths, so on the Linux jump-box they ENOENT-crashed at MCP startup. Gated to `darwin`; off-Mac those tools are reached through the **toolhive** gateway — verified to expose exactly two tools (`call_tool`/`find_tool`), i.e. a thin router, not an aggregator. `gitops` keeps kubectl/flux direct on macOS and falls back to the toolhive router off-Mac.

### Drop the memory MCP (`ff1aaa9`)
`@modelcontextprotocol/server-memory` is redundant now that the memini plugin provides memory. Removed the server + its agent/profile disables from both configs.

### Renovate for opencode plugins (`cf3d2a5`)
Added a custom manager so version-pinned opencode plugins inside `opencode.json.tmpl` (e.g. `@eleboucher/opencode-memini`) are tracked on the npm datasource — the shared preset has none. Config validated against latest renovate.

## Verification
Both templates render to valid config for linux (and darwin) via the jump-box's own chezmoi. Work overlay is untouched (it never had memory/toolhive). The `superpowers` git-pin is intentionally left unmanaged (git-commit pin, not npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)