### PR TITLE
chore: dotfiles audit — Brewfile, Renovate coverage, fixes

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,6 +5,11 @@
     'github>joryirving/renovate-config',
     ':semanticCommits',
   ],
+  // Track the private `work` overlay submodule — advances the pinned commit to
+  // the tip of its default branch (main). Disabled by default in Renovate.
+  'git-submodules': {
+    enabled: true,
+  },
   customManagers: [
     {
       customType: 'regex',
@@ -14,6 +19,27 @@
       matchStrings: ['(?<depName>@[\\w.-]+/[\\w.-]+)@(?<currentValue>\\d[\\w.-]*)'],
       datasourceTemplate: 'npm',
       versioningTemplate: 'npm',
+    },
+    {
+      customType: 'regex',
+      description: 'superpowers opencode plugin pinned to a git commit',
+      managerFilePatterns: ['/opencode\\.json\\.tmpl$/'],
+      // "superpowers@git+https://github.com/obra/superpowers.git#f2cbfbe"
+      matchStrings: ['superpowers@git\\+https://github\\.com/obra/superpowers\\.git#(?<currentDigest>[a-f0-9]+)'],
+      datasourceTemplate: 'git-refs',
+      depNameTemplate: 'obra/superpowers',
+      packageNameTemplate: 'https://github.com/obra/superpowers',
+      currentValueTemplate: 'main',
+    },
+  ],
+  packageRules: [
+    {
+      // superpowers runs inside the agent with full tool access — never
+      // auto-merge. Open a PR so the new commit can be re-scanned for prompt
+      // injection / exfiltration before the pin moves.
+      matchPackageNames: ['obra/superpowers'],
+      automerge: false,
+      addLabels: ['security-review'],
     },
   ],
 }

--- a/home/dot_Brewfile.tmpl
+++ b/home/dot_Brewfile.tmpl
@@ -1,0 +1,95 @@
+# =============================================================================
+# ~/.Brewfile — declarative Homebrew manifest (managed by chezmoi).
+# Applied via `brew bundle --global` from the run_onchange_ script on apply.
+#
+# Layout follows chezmoi's two axes:
+#   core            → all machines
+#   .personal       → personal mac + rpi5 (not the work mac)
+#   os == darwin    → both macs, then split work vs personal
+#   else (linux)    → rpi5 (always personal — no work linux)
+#
+# Tool overlap is deliberately avoided: kustomize/kubeconform/stern/minijinja
+# and language toolchains (go/rust/python) are managed by mise, not brew.
+# =============================================================================
+
+# ── core (all machines) ──────────────────────────────────────────────────
+brew "atuin"
+brew "chezmoi"
+brew "fastfetch"
+brew "fish"
+brew "gh"
+brew "helm"
+brew "k9s"
+brew "krew"
+brew "kubecolor"
+brew "starship"
+brew "viddy"
+brew "yq"
+brew "zoxide"
+{{- if .personal }}
+
+# ── personal machines (personal mac + rpi5) ──────────────────────────────
+brew "jq"
+{{- end }}
+
+{{- if eq .chezmoi.os "darwin" }}
+
+# ── macOS (both macs) ────────────────────────────────────────────────────
+brew "coreutils"
+brew "colima"
+brew "docker"
+brew "docker-compose"
+brew "htop"
+brew "iperf3"
+brew "kubectx"
+brew "opentofu"
+brew "prettier"
+brew "tree"
+brew "yamllint"
+cask "ghostty"
+cask "1password-cli"
+{{- if .personal }}
+
+# ── personal mac ─────────────────────────────────────────────────────────
+brew "age"
+brew "sops"
+brew "direnv"
+brew "kind"
+brew "helmfile"
+brew "tflint"
+brew "pre-commit"
+brew "ripgrep"
+brew "lsd"
+brew "tmux"
+brew "uv"
+brew "wget"
+brew "watch"
+brew "git"
+brew "moreutils"
+brew "openclaw/tap/openclaw-cli"
+cask "1password"
+{{- else }}
+
+# ── work mac ─────────────────────────────────────────────────────────────
+brew "bash"
+brew "awscli"
+brew "gomplate"
+brew "git-lfs"
+brew "hey"
+brew "ko"
+brew "common-fate/granted/granted"
+brew "hashicorp/tap/terraform"
+brew "controlplaneio-fluxcd/tap/flux-operator-mcp"
+brew "keidarcy/tap/e1s"
+cask "dbeaver-community"
+cask "rectangle"
+cask "session-manager-plugin"
+{{- end }}
+{{- else }}
+
+# ── rpi5 (linux, personal) ───────────────────────────────────────────────
+brew "bat"
+brew "gcc"
+brew "handfish/tap/talos-pilot"
+brew "nano-collective/nanocoder/nanocoder"
+{{- end }}

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -1,3 +1,7 @@
 function fish_greeting
-    fastfetch
+    # fastfetch comes from the Brewfile; guard so shells opened before
+    # `brew bundle` has run on a fresh machine don't error.
+    if type -q fastfetch
+        fastfetch
+    end
 end

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -12,3 +12,4 @@ experimental = true
 "aqua:kubernetes-sigs/kustomize" = "latest"
 "aqua:stern/stern" = "latest"
 "aqua:mitsuhiko/minijinja" = "latest"
+"npm:oxfmt" = "latest"  # JS/TS formatter (needs npm/node available)

--- a/home/dot_config/topgrade.toml
+++ b/home/dot_config/topgrade.toml
@@ -27,7 +27,6 @@ disable = [
   "linux_update",
   # other
   "restarts",       # don't restart services after update
-  "v Box",          # VirtualBox — usually managed manually
 ]
 
 # ── Things you DO want updated ────────────────────────────────────────────

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -10,8 +10,6 @@
 {{- if or (eq .chezmoi.os "darwin") (and (eq .chezmoi.os "linux") (.chezmoi.kernel.osrelease | lower | contains "microsoft")) }}
 [gpg]
   format = ssh
-{{- end }}
-{{- if or (eq .chezmoi.os "darwin") (and (eq .chezmoi.os "linux") (.chezmoi.kernel.osrelease | lower | contains "microsoft")) }}
 [gpg "ssh"]
 {{- if (eq .chezmoi.os "darwin") }}
   program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign

--- a/home/run_onchange_after_install-packages.sh.tmpl
+++ b/home/run_onchange_after_install-packages.sh.tmpl
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Sync Homebrew packages from ~/.Brewfile. Runs on `chezmoi apply` whenever the
+# Brewfile changes (its hash is embedded below, so this reruns on every edit).
+# =============================================================================
+set -uo pipefail
+
+# Brewfile hash: {{ include "dot_Brewfile.tmpl" | sha256sum }}
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "[INFO] brew not found; skipping brew bundle" >&2
+  exit 0
+fi
+
+echo "[INFO] brew bundle --global (install missing packages)..." >&2
+# --no-upgrade: leave upgrades to topgrade. --no-lock: don't write ~/.Brewfile.lock.json.
+if ! brew bundle install --global --no-upgrade --no-lock; then
+  echo "[WARN] brew bundle reported failures; continuing apply" >&2
+fi


### PR DESCRIPTION
Audit pass over the repo. Three logical commits.

## Fixes
- `fish_greeting` guards `fastfetch` with `type -q` — fresh shells no longer error before it's installed.
- Removed the bogus `"v Box"` topgrade step (invalid → silent no-op).
- Merged two adjacent gitconfig `[gpg]`/`[gpg "ssh"]` blocks sharing one OS condition (output is byte-identical).

## Renovate
- Custom manager for the git-pinned `superpowers` opencode plugin. **Notify-only**: `automerge:false` + `security-review` label, so the pin only moves via a PR you can re-scan first.
- Enabled the `git-submodules` manager so the private `work` overlay tracks its default branch. *Needs Renovate read access to `dotfiles-work`.*

## Brew
- New `~/.Brewfile` templated by `os` + `.personal`, plus a `run_onchange_` script running `brew bundle --global --no-upgrade --no-lock` on apply.
- Curated across work mac / personal mac / rpi5. Avoids double-management: `kustomize`/`kubeconform`/`stern`/`minijinja` + language toolchains stay with mise; `oxfmt` moved to mise (`npm:oxfmt`).
- Script is **install-only** — pruning the personal mac's existing cruft is a manual `brew bundle cleanup` when you're ready.

All template branches rendered and verified for each machine combo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)